### PR TITLE
Removed ignorecase default

### DIFF
--- a/init/options.vim
+++ b/init/options.vim
@@ -50,7 +50,6 @@ set laststatus=2                " Always show statusline
 
 set incsearch                   " Incremental search
 set history=1024                " History size
-set ignorecase                  " Ignore case by default
 set smartcase                   " Smart case-sensitivity when searching (overrides ignorecase)
 
 set autoread                    " No prompt for file changes outside Vim


### PR DESCRIPTION
This returns search and replace to a state where it is case sensitive. 

An example of the incorrect behavior we're experiencing:

`:%s/ClassName/NewClassName` is interpreted as `:%s/ClassName/NewClassName/i`

My understanding is that `set ignoredcase` was introduced for the benefit of inline search.
With this change you would need to modify your inline search behavior:

Instead of writing:

```
/someinterestingclass
```

Use the `\c` flag ([more info](http://vim.wikia.com/wiki/Searching#Case_sensitivity)):

```
/someinterstingclass\c
```

or use the correct case:

```
/SomeInterestingClass
```

Cheers,
Dirk Kelly
