### PR TITLE
Update RSpec "it" snippet to not use "should"

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -7,7 +7,7 @@ snippet cont Context
 		${2}
 	end
 snippet it it block
-	it "${1:should do something}" do
+	it "${1:does something}" do
 		${2}
 	end
 snippet bef Before each test


### PR DESCRIPTION
``` ruby
describe "using 'should' in 'it' blocks"
  it "makes for poorly named tests" do
    it should_not be_encouraged
  end
end
```
