### PR TITLE
Use correct reference to vim-slim repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -95,7 +95,7 @@
 	ignore = dirty
 [submodule "bundle/vim-slim"]
 	path = bundle/vim-slim
-	url = git://github.com/bbommarito/vim-slim.git
+	url = git://github.com/slim-template/vim-slim.git
 [submodule "bundle/gundo"]
 	path = bundle/gundo
 	url = https://github.com/sjl/gundo.vim.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # To Install
 (Re)move ~/.vim and ~/.vimrc if you have them already, and run:
 
-    git clone git://github.com/pivotal/vim-config.git ~/.vim
+    git clone git://github.com/pivotalforks/vim-config.git ~/.vim
     cd ~/.vim
     git submodule update --init
     ln -s ~/.vim/vimrc ~/.vimrc


### PR DESCRIPTION
Use real `vim-slim` repo, otherwise you get `repo not found` errors.
Also change readme directions to reference `pivotalforks/vim-config.git` instead of `pivotal/vim-config.git`
